### PR TITLE
Rename remaining .open classes to .close

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -169,50 +169,50 @@ button span {
   top: -1.14286rem;
 }
 
-.lines-button.open {
+.lines-button.close {
   -webkit-transform: scale3d(0.8, 0.8, 0.8);
   transform: scale3d(0.8, 0.8, 0.8);
 }
 
-.lines-button.arrow.open .lines:before, .lines-button.arrow.open .lines:after {
+.lines-button.arrow.close .lines:before, .lines-button.arrow.close .lines:after {
   top: 0;
   width: 2.22222rem;
 }
-.lines-button.arrow.open .lines:before {
+.lines-button.arrow.close .lines:before {
   -webkit-transform: rotate3d(0, 0, 1, 40deg);
   transform: rotate3d(0, 0, 1, 40deg);
 }
-.lines-button.arrow.open .lines:after {
+.lines-button.arrow.close .lines:after {
   -webkit-transform: rotate3d(0, 0, 1, -40deg);
   transform: rotate3d(0, 0, 1, -40deg);
 }
 
-.lines-button.arrow-up.open {
+.lines-button.arrow-up.close {
   -webkit-transform: scale3d(0.8, 0.8, 0.8) rotate3d(0, 0, 1, 90deg);
   transform: scale3d(0.8, 0.8, 0.8) rotate3d(0, 0, 1, 90deg);
 }
 
-.lines-button.minus.open .lines:before, .lines-button.minus.open .lines:after {
+.lines-button.minus.close .lines:before, .lines-button.minus.close .lines:after {
   -webkit-transform: none;
   transform: none;
   top: 0;
   width: 4rem;
 }
 
-.lines-button.x.open .lines {
+.lines-button.x.close .lines {
   background: transparent;
 }
-.lines-button.x.open .lines:before, .lines-button.x.open .lines:after {
+.lines-button.x.close .lines:before, .lines-button.x.close .lines:after {
   -webkit-transform-origin: 50% 50%;
   transform-origin: 50% 50%;
   top: 0;
   width: 4rem;
 }
-.lines-button.x.open .lines:before {
+.lines-button.x.close .lines:before {
   -webkit-transform: rotate3d(0, 0, 1, 45deg);
   transform: rotate3d(0, 0, 1, 45deg);
 }
-.lines-button.x.open .lines:after {
+.lines-button.x.close .lines:after {
   -webkit-transform: rotate3d(0, 0, 1, -45deg);
   transform: rotate3d(0, 0, 1, -45deg);
 }
@@ -227,21 +227,21 @@ button span {
   transition: top 0.3s 0.6s ease, transform 0.3s ease;
 }
 
-.lines-button.x2.open .lines {
+.lines-button.x2.close .lines {
   transition: background 0.3s 0s ease;
   background: transparent;
 }
-.lines-button.x2.open .lines:before, .lines-button.x2.open .lines:after {
+.lines-button.x2.close .lines:before, .lines-button.x2.close .lines:after {
   transition: top 0.3s ease, -webkit-transform 0.3s 0.5s ease;
   transition: top 0.3s ease, transform 0.3s 0.5s ease;
   top: 0;
   width: 4rem;
 }
-.lines-button.x2.open .lines:before {
+.lines-button.x2.close .lines:before {
   -webkit-transform: rotate3d(0, 0, 1, 45deg);
   transform: rotate3d(0, 0, 1, 45deg);
 }
-.lines-button.x2.open .lines:after {
+.lines-button.x2.close .lines:after {
   -webkit-transform: rotate3d(0, 0, 1, -45deg);
   transform: rotate3d(0, 0, 1, -45deg);
 }


### PR DESCRIPTION
The `lines-button`s didn't animate to arrows/crosses because the `close` class was being added to them but the class was named `open` in the CSS file. I changed all occurrences of `.open` in style.css to `.close` to match the `grid-button`s, and the animation now works as expected.
